### PR TITLE
Fixes #47 - windows portable app

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -19,11 +19,15 @@
   ],
   "win": {
     "target": [
-      "nsis"
+      "nsis",
+      "portable"
     ]
   },
   "nsis": {
     "perMachine": true
+  },
+  "portable": {
+    "artifactName": "${productName}-${version}-portable.${ext}"
   },
   "mac": {
     "category": "public.app-category.graphics-design",


### PR DESCRIPTION
This change packages a portable windows application as well as the standard installer.
I tested the build on Win10 with a self-signed certificate and without access to administrative privileges.
I am happily using it in this fashion.

Many thanks again for your care and this most awesome project.